### PR TITLE
Fix watcher error

### DIFF
--- a/scripts/watchers/memory_watcher_updated.py
+++ b/scripts/watchers/memory_watcher_updated.py
@@ -45,8 +45,8 @@ def run_parser(src):
     if result.returncode == 0:
         print(result.stdout.strip())
     else:
-        print(f"❌ Parser error for {src.name}:
-{result.stderr.strip()}")
+        # Preserve newline in output while keeping string on one line
+        print(f"❌ Parser error for {src.name}:\n{result.stderr.strip()}")
 
 class Handler(FileSystemEventHandler):
     def on_modified(self, event):


### PR DESCRIPTION
## Summary
- fix syntax error in `memory_watcher_updated.py`

## Testing
- `python -m py_compile scripts/watchers/memory_watcher_updated.py`
- `git ls-files '*.py' | while read -r f; do python -m py_compile "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_687a252b4334833081c1e024ca52e2b7